### PR TITLE
update: on ssl-exporter serviceMonitor add default relabelings action.

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -18,7 +18,7 @@ description: A Helm chart for ribbybibby/ssl_exporter
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.2.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/chart/templates/_servicemonitor.tpl
+++ b/chart/templates/_servicemonitor.tpl
@@ -55,6 +55,7 @@ spec:
       relabelings:
       - targetLabel: job
         replacement: ssl-kubernetes-files
+        action: replace
     {{- end }}
   {{- if $masternode }}
     # Kubeconfig certificates
@@ -71,8 +72,10 @@ spec:
       relabelings:
       - sourceLabels: [__param_target]
         targetLabel: target
+        action: replace
       - targetLabel: job
         replacement: ssl-kubernetes-kubeconfig
+        action: replace
 
     {{- end }}
   {{- else }}
@@ -88,6 +91,7 @@ spec:
       relabelings:
       - targetLabel: job
         replacement: ssl-external-url
+        action: replace
       metricRelabelings:
       - action: labeldrop
         regex: instance
@@ -108,6 +112,7 @@ spec:
       relabelings:
       - targetLabel: job
         replacement: ssl-kubernetes-secrets
+        action: replace
       metricRelabelings:
       - action: labeldrop
         regex: instance


### PR DESCRIPTION
if relabelings `action: replace` is ignored, it will be `OutOfSync` sync status on Argo-CD.

if you have argo-cd alert by application  sync status, it will be firing alerts.

![image](https://github.com/user-attachments/assets/0141825e-1e59-4afe-93d9-79cbc72a27cb)

![image](https://github.com/user-attachments/assets/181e627b-1d1e-4b49-96d0-105b2a4d01c9)

![image](https://github.com/user-attachments/assets/46e0d374-bced-40a8-8f2d-7ec5b69e1b74)
